### PR TITLE
Modernize project and fix build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _book/
 !menu.md
 !_navbar.md
 CMakeSettings.json
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.10)
-set(CMAKE_MODULE_PATH 
+cmake_minimum_required(VERSION 3.21)
+set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_LIST_DIR}/modules"
 )
@@ -7,7 +7,6 @@ set(CMAKE_MODULE_PATH
 project(Doxybook2)
 
 if(USE_CPM)
-  
   include(cmake/CPM.cmake)
 
   CPMAddPackage(
@@ -25,12 +24,13 @@ if(USE_CPM)
     NAME nlohmann_json
     GITHUB_REPOSITORY nlohmann/json
     VERSION 3.9.1
-    OPTIONS 
+    OPTIONS
       "JSON_BuildTests OFF"
   )
   CPMAddPackage("gh:gabime/spdlog#v1.9.1")
   CPMAddPackage("gh:jarro2783/cxxopts#v2.2.1")
-  if (MSVC)
+
+  if(MSVC)
     CPMAddPackage("gh:tronkko/dirent#1.23.2")
   endif()
 endif()
@@ -48,6 +48,7 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithD
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/Doxybook)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/DoxybookCli)
+
 if(DOXYBOOK_TESTS)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests/DoxybookTests)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,30 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "Windows",
+            "generator": "Visual Studio 17 2022",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "Windows-Debug",
+            "configurePreset": "Windows",
+            "configuration": "Debug"
+        },
+        {
+            "name": "Windows-MinSizeRel",
+            "configurePreset": "Windows",
+            "configuration": "MinSizeRel"
+        },
+        {
+            "name": "Windows-Release",
+            "configurePreset": "Windows",
+            "configuration": "Release"
+        }
+    ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,8 @@ The MIT License
 
 Copyright (c) 2019-2020 Matus Novak email@matusnovak.com
 
+Copyright (c) 2024 Anton Breusov anton.breusov@gmail.com
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/src/Doxybook/CMakeLists.txt
+++ b/src/Doxybook/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 project(Doxybook2)
 
 # Dependencies
@@ -7,7 +7,8 @@ if(NOT USE_CPM)
   find_package(fmt CONFIG REQUIRED)
   find_package(nlohmann_json CONFIG REQUIRED)
   find_package(spdlog CONFIG REQUIRED)
-  if (MSVC)
+
+  if(MSVC)
     find_package(Dirent REQUIRED)
   endif()
 endif()
@@ -23,6 +24,14 @@ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "doxybook2")
 target_include_directories(${PROJECT_NAME} PUBLIC ${DOXYDOWN_INCLUDE_DIR})
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 
+if(MSVC)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
+
+  # See issue there: https://github.com/actions/runner-images/issues/10004#issuecomment-2156109231
+  # and there: https://github.com/gabime/spdlog/issues/3119#issuecomment-2218733127
+  target_compile_definitions(${PROJECT_NAME} PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 # Install
 install(TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}
@@ -36,6 +45,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../include
 
 # Libraries
 target_link_libraries(${PROJECT_NAME} PUBLIC fmt::fmt fmt::fmt-header-only spdlog::spdlog_header_only pantor::inja nlohmann_json nlohmann_json::nlohmann_json)
+
 if(MSVC)
   target_link_libraries(${PROJECT_NAME} PRIVATE Dirent)
 endif()

--- a/src/DoxybookCli/CMakeLists.txt
+++ b/src/DoxybookCli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 project(Doxybook2Cli)
 
 # Project source files
@@ -19,6 +19,14 @@ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "doxybook2")
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src/Doxybook)
 target_compile_definitions(${PROJECT_NAME} PRIVATE VERSION=${VERSION})
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
+
+if(MSVC)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
+
+  # See issue there: https://github.com/actions/runner-images/issues/10004#issuecomment-2156109231
+  # and there: https://github.com/gabime/spdlog/issues/3119#issuecomment-2218733127
+  target_compile_definitions(${PROJECT_NAME} PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
 
 if(DOXYBOOK_STATIC_STDLIB)
   target_link_libraries(${PROJECT_NAME} PRIVATE -static-libgcc -static-libstdc++)

--- a/tests/DoxybookTests/CMakeLists.txt
+++ b/tests/DoxybookTests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(Doxybook2Tests)
 
 # Dependencies

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,8 +2,34 @@
   "name": "doxybook2",
   "version-string": "1.5.0",
   "builtin-baseline": "1085a57da0725c19e19586025438e8c16f34c890",
-  "dependencies": [ "catch2", "fmt", "dirent", "fmt", "nlohmann-json", "inja", "cxxopts", "spdlog" ],
-  "overrides": [
-    { "name": "catch2", "version": "2.13.8" }
+  "dependencies": [
+    {
+      "name": "catch2",
+      "version>=": "3.8.0"
+    },
+    {
+      "name": "spdlog",
+      "version>=": "1.15.1"
+    },
+    {
+      "name": "inja",
+      "version>=": "3.4.0"
+    },
+    {
+      "name": "fmt",
+      "version>=": "11.0.2"
+    },
+    {
+      "name": "cxxopts",
+      "version>=": "3.2.1"
+    },
+    {
+      "name": "dirent",
+      "version>=": "1.23.2"
+    },
+    {
+      "name": "nlohmann-json",
+      "version>=": "3.11.3"
+    }
   ]
 }


### PR DESCRIPTION
# Changes.
- Added `CMakePresets.json` to be a baseline for user presets for local builds.
- Bumped CMake requirements to 3.21 because we use now presets features that require it.
- Added some defines to suppress very verbose MSVC warnings in third-party code.
- Added critical tweak to MSVC builds (`_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR`), see notes in `CMakeLists.txt` comments.