### PR TITLE
fix: Fixed issue with a default template "member_details".

### DIFF
--- a/src/Doxybook/DefaultTemplates.cpp
+++ b/src/Doxybook/DefaultTemplates.cpp
@@ -380,8 +380,7 @@ static std::string createTableForAttributeLike(const std::string& visibility,
     return ss.str();
 }
 
-static std::string createTableForJavaEnumConstants(const std::string& title,
-    const std::string& key) {
+static std::string createTableForJavaEnumConstants(const std::string& title, const std::string& key) {
     std::stringstream ss;
     ss << "{%- if exists(\"" << key << "\") %}";
     ss << "## " << title << "\n";
@@ -395,7 +394,6 @@ static std::string createTableForJavaEnumConstants(const std::string& title,
 
     return ss.str();
 }
-
 
 static std::string createTableForFriendLike(const std::string& title, const std::string& key, const bool inherited) {
     std::stringstream ss;
@@ -585,7 +583,8 @@ static std::string createNonMemberTable() {
 {% endif -%})";
     ss << "\n\n";
 
-    ss << createTableForNamespaceLike("public", R"({% if language == "java" %}Packages{% else %}Namespaces{% endif %})", "namespaces", false);
+    ss << createTableForNamespaceLike(
+        "public", R"({% if language == "java" %}Packages{% else %}Namespaces{% endif %})", "namespaces", false);
     ss << createTableForClassLike("public", "Classes", "publicClasses", false);
     ss << createTableForTypeLike("public", "Types", "publicTypes", false);
     ss << createTableForFunctionLike("public", "Slots", "publicSlots", false);
@@ -635,7 +634,7 @@ template <{% for param in templateParams %}{{param.typePlain}} {{param.name}}{% 
 | Enumerator | Value | Description |
 | ---------- | ----- | ----------- |
 {% for enumvalue in enumvalues %}| {{enumvalue.name}} | {% if existsIn(enumvalue, "initializer") -%}
-{{replace(replace(enumvalue.initializer, "= ", ""), "|", "\\|"))}}{% endif -%}
+{{replace(replace(enumvalue.initializer, "= ", ""), "|", "\\|")}}{% endif -%}
 | {% if existsIn(enumvalue, "brief") %}{{enumvalue.brief}}{% endif %} {% if existsIn(enumvalue, "details") %}{{enumvalue.details}}{% endif %} |
 {% endfor %}
 {% endif -%}

--- a/src/DoxybookCli/main.cpp
+++ b/src/DoxybookCli/main.cpp
@@ -11,7 +11,6 @@
 #include <spdlog/spdlog.h>
 #include <string>
 
-
 #define xstr(a) str(a)
 #define str(a) #a
 
@@ -85,7 +84,7 @@ int main(int argc, char* argv[]) {
         }
 
         else if (args["version"].as<bool>()) {
-            std::cerr << version;
+            std::cerr << version << std::endl;
             return EXIT_SUCCESS;
         }
 


### PR DESCRIPTION
# Changes
- `src\Doxybook\DefaultTemplates.cpp`: Issue was uncovered after updating [inja](https://github.com/pantor/inja/releases) template engine from version 3.1.0 to 3.4.0, because it added more strict checks for matching closing parenthesis, and there was one unneeded in this template.
- `src\DoxybookCli\main.cpp`: put new-line after outputting version number.