### PR TITLE
fix: Java enum constants links were broken.

### DIFF
--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -254,7 +254,7 @@ void Doxybook2::Node::parseInheritanceInfo(const Xml::Element& element) {
 void Doxybook2::Node::makeUrl(const Config& config) {
     static const auto anchorMaker = [](const Config& config, const Node& node) {
         if (!node.isStructured() && node.kind != Kind::MODULE) {
-            return "#" + Utils::toLower(toStr(node.kind)) + "-" +
+            return "#" + Utils::toLower(Utils::safeAnchorId(toStr(node.kind), false)) + "-" +
                    Utils::safeAnchorId(node.name, config.replaceUnderscoresInAnchors);
         } else {
             return std::string("");

--- a/src/Doxybook/Utils.cpp
+++ b/src/Doxybook/Utils.cpp
@@ -7,12 +7,14 @@
 
 #include "ExceptionUtils.hpp"
 #include <Doxybook/Utils.hpp>
+#include <cctype>
 #include <chrono>
 #include <dirent.h>
 #include <locale>
 #include <regex>
 #include <sstream>
 #include <unordered_map>
+
 
 static std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
     size_t pos = 0;
@@ -50,13 +52,13 @@ std::string Doxybook2::Utils::replaceNewline(std::string str) {
 
 std::string Doxybook2::Utils::title(std::string str) {
     if (!str.empty())
-        str[0] = ::toupper(str[0]);
+        str[0] = std::toupper(str[0]);
     return str;
 }
 
 extern std::string Doxybook2::Utils::toLower(std::string str) {
     for (auto& c : str) {
-        c = ::tolower(c);
+        c = std::tolower(c);
     }
     return str;
 }


### PR DESCRIPTION
Doxygen entities of "kind" equal to "variable" with empty `<type>` child tag, which are mapped to internal  Kind::JAVAENUMCONSTANT (Java enums constants) were written as "enum constant" (with space) in the generated links URLs. It causes links to be broken. Spaces must be replaced with `-` instead of space, this is what Markdown processors use to replace spaces with in generated anchors.