### PR TITLE
feat: Fix Java links being inside code blocks.

### DIFF
--- a/include/Doxybook/TextMarkdownPrinter.hpp
+++ b/include/Doxybook/TextMarkdownPrinter.hpp
@@ -3,14 +3,14 @@
 #include <sstream>
 namespace Doxybook2 {
     class TextMarkdownPrinter : public TextPrinter {
-      public:
+    public:
         explicit TextMarkdownPrinter(const Config& config, std::string inputDir, const Doxygen& doxygen)
             : TextPrinter(config, doxygen), inputDir(std::move(inputDir)) {
         }
 
         std::string print(const XmlTextParser::Node& node, const std::string& language) const override;
 
-      private:
+    private:
         struct ListData {
             int counter{0};
             bool ordered{false};
@@ -24,6 +24,7 @@ namespace Doxybook2 {
             bool eol{false};
             bool tableHeader{false};
             bool inComputerOutput{false};
+            bool invertComputerOutput{false};
             bool validLink{false};
         };
 


### PR DESCRIPTION
When processing links in Java code (`{@link class#method(argType1, argType2, argType3)}`) Doxygen wraps them first in the `<computeroutput>` tag (a Doxygen semantic for `<code>` tag in Markdown) and inside in the `<ref>` tag (used for creating various links).

It leads to putting links inside code, which is not valid, those links will not be parsed, unless `linkAndInlineCodeAsHTML` config option is used (which can be also problematic in some cases).

Added a hack-tweak that when we encounter such case (a `<computeroutput>` tag with a single `<ref>` tag in it), and `linkAndInlineCodeAsHTML` option is not set, we effectively inverting them, by putting links braces over code marks (backtick).